### PR TITLE
feat: Add session reset options and category lock during active timer (v1.0.4)

### DIFF
--- a/components/pomodoro/liquid-timer.tsx
+++ b/components/pomodoro/liquid-timer.tsx
@@ -4,7 +4,7 @@ import { useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { useAppStore } from '@/lib/store';
 import { cn } from '@/lib/utils';
-import { Play, Pause, RotateCcw, SkipForward } from 'lucide-react';
+import { Play, Pause, RotateCcw, SkipForward, RefreshCw } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Category } from '@/lib/types';
 import { CATEGORY_COLORS, CATEGORY_ICONS, CATEGORY_LABELS } from '@/lib/constants';
@@ -24,6 +24,7 @@ export function LiquidTimer() {
     tick,
     selectedCategory,
     setSelectedCategory,
+    resetSessions,
   } = useAppStore();
 
   const intervalRef = useRef<NodeJS.Timeout | null>(null);
@@ -97,6 +98,19 @@ export function LiquidTimer() {
         <p className="text-muted-foreground mt-1 text-xs">
           Session {(completedSessions % settings.sessionsUntilLongBreak) + 1} of {settings.sessionsUntilLongBreak}
         </p>
+        {(completedSessions % settings.sessionsUntilLongBreak) > 0 && (
+          <button
+            onClick={() => {
+              if (confirm('Reset to session 1?')) {
+                resetSessions();
+              }
+            }}
+            className="text-muted-foreground hover:text-warning mt-2 flex items-center gap-1 text-xs transition-colors"
+          >
+            <RefreshCw className="h-3 w-3" />
+            <span>Reset Sessions</span>
+          </button>
+        )}
       </motion.div>
 
       {/* Category Selector */}
@@ -307,15 +321,17 @@ export function LiquidTimer() {
         {(Object.keys(CATEGORY_COLORS) as Category[]).map((category) => {
           const Icon = CATEGORY_ICONS[category];
           const isSelected = selectedCategory === category;
-          
+
           return (
             <motion.button
               key={category}
               onClick={() => setSelectedCategory(category)}
+              disabled={isActive}
               className={cn(
                 'flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium transition-all',
                 'border backdrop-blur-sm',
-                isSelected ? 'bg-background/80' : 'bg-background/30'
+                isSelected ? 'bg-background/80' : 'bg-background/30',
+                isActive && 'cursor-not-allowed opacity-50'
               )}
               style={{
                 color: isSelected ? CATEGORY_COLORS[category] : '#6B7280',
@@ -325,15 +341,15 @@ export function LiquidTimer() {
                 scale: isSelected ? 1 : 0.85,
                 opacity: isSelected ? 1 : 0.6,
               }}
-              whileHover={{ 
+              whileHover={!isActive ? {
                 scale: isSelected ? 1.05 : 0.9,
                 opacity: 1,
-              }}
-              whileTap={{ scale: 0.95 }}
-              transition={{ 
-                type: "spring", 
-                stiffness: 400, 
-                damping: 17 
+              } : {}}
+              whileTap={!isActive ? { scale: 0.95 } : {}}
+              transition={{
+                type: "spring",
+                stiffness: 400,
+                damping: 17
               }}
             >
               <Icon className="h-3 w-3" />

--- a/components/settings/settings-view.tsx
+++ b/components/settings/settings-view.tsx
@@ -6,13 +6,13 @@ import { Label } from '@/components/ui/label';
 import { Slider } from '@/components/ui/slider';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
-import { Moon, Sun, Clock, Coffee, Battery, Download, Upload, Database, Volume2, VolumeX } from 'lucide-react';
+import { Moon, Sun, Clock, Coffee, Battery, Download, Upload, Database, Volume2, VolumeX, RefreshCw, Trash2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { DonationModal } from './donation-modal';
 import { UpdatesModal } from './updates-modal';
 
 export function SettingsView() {
-  const { settings, updateSettings, isDarkMode, toggleDarkMode } =
+  const { settings, updateSettings, isDarkMode, toggleDarkMode, resetSessions, hardReset } =
     useAppStore();
 
   return (
@@ -170,98 +170,147 @@ export function SettingsView() {
           </div>
         </div>
 
-      <div className="space-y-4">
-        <h3 className="text-muted-foreground text-sm font-medium">
-          Data & Storage
-        </h3>
-        <div className="bg-card space-y-4 rounded-xl border p-4">
-          <div className="flex items-center gap-2 mb-2">
-            <Database className="text-primary h-4 w-4" />
-            <Label className="text-foreground">Backup & Restore</Label>
-          </div>
-          
-          <div className="grid grid-cols-2 gap-3">
-            <Button 
-              variant="outline" 
-              className="w-full justify-start overflow-hidden" 
-              onClick={() => {
-                try {
-                  const storageData = localStorage.getItem('flow-state-storage');
-                  if (!storageData) {
-                    toast.error('No data found to export');
-                    return;
-                  }
-                  
-                  const blob = new Blob([storageData], { type: 'application/json' });
-                  const url = URL.createObjectURL(blob);
-                  const a = document.createElement('a');
-                  a.href = url;
-                  a.download = `productivity-app-backup-${new Date().toISOString().split('T')[0]}.json`;
-                  document.body.appendChild(a);
-                  a.click();
-                  document.body.removeChild(a);
-                  URL.revokeObjectURL(url);
-                  
-                  toast.success('Backup downloaded successfully');
-                } catch (error) {
-                  console.error('Export failed:', error);
-                  toast.error('Failed to export data');
-                }
-              }}
-            >
-              <Download className="mr-2 h-4 w-4 shrink-0" />
-              <span className="truncate">Export Backup</span>
-            </Button>
+        <div className="space-y-4">
+          <h3 className="text-muted-foreground text-sm font-medium">
+            Data & Storage
+          </h3>
+          <div className="bg-card space-y-4 rounded-xl border p-4">
+            <div className="flex items-center gap-2 mb-2">
+              <Database className="text-primary h-4 w-4" />
+              <Label className="text-foreground">Backup & Restore</Label>
+            </div>
 
-            <div className="relative">
-              <input
-                type="file"
-                accept=".json"
-                className="absolute inset-0 cursor-pointer opacity-0"
-                onChange={(e) => {
-                  const file = e.target.files?.[0];
-                  if (!file) return;
-
-                  const reader = new FileReader();
-                  reader.onload = (event) => {
-                    try {
-                      const json = event.target?.result as string;
-                      const parsed = JSON.parse(json);
-                      
-                      // Basic validation
-                      if (!parsed || !parsed.state) {
-                         throw new Error('Invalid backup file format');
-                      }
-
-                      localStorage.setItem('flow-state-storage', json);
-                      toast.success('Data restored successfully! Reloading...');
-                      
-                      setTimeout(() => {
-                        window.location.reload();
-                      }, 1500);
-                    } catch (error) {
-                      console.error('Import failed:', error);
-                      toast.error('Failed to restore data. Invalid file.');
+            <div className="grid grid-cols-2 gap-3">
+              <Button
+                variant="outline"
+                className="w-full justify-start overflow-hidden"
+                onClick={() => {
+                  try {
+                    const storageData = localStorage.getItem('flow-state-storage');
+                    if (!storageData) {
+                      toast.error('No data found to export');
+                      return;
                     }
-                  };
-                  reader.readAsText(file);
-                  
-                  // Reset input
-                  e.target.value = '';
+
+                    const blob = new Blob([storageData], { type: 'application/json' });
+                    const url = URL.createObjectURL(blob);
+                    const a = document.createElement('a');
+                    a.href = url;
+                    a.download = `productivity-app-backup-${new Date().toISOString().split('T')[0]}.json`;
+                    document.body.appendChild(a);
+                    a.click();
+                    document.body.removeChild(a);
+                    URL.revokeObjectURL(url);
+
+                    toast.success('Backup downloaded successfully');
+                  } catch (error) {
+                    console.error('Export failed:', error);
+                    toast.error('Failed to export data');
+                  }
                 }}
-              />
-              <Button variant="outline" className="w-full justify-start overflow-hidden pointer-events-none">
-                <Upload className="mr-2 h-4 w-4 shrink-0" />
-                <span className="truncate">Import Backup</span>
+              >
+                <Download className="mr-2 h-4 w-4 shrink-0" />
+                <span className="truncate">Export Backup</span>
+              </Button>
+
+              <div className="relative">
+                <input
+                  type="file"
+                  accept=".json"
+                  className="absolute inset-0 cursor-pointer opacity-0"
+                  onChange={(e) => {
+                    const file = e.target.files?.[0];
+                    if (!file) return;
+
+                    const reader = new FileReader();
+                    reader.onload = (event) => {
+                      try {
+                        const json = event.target?.result as string;
+                        const parsed = JSON.parse(json);
+
+                        // Basic validation
+                        if (!parsed || !parsed.state) {
+                          throw new Error('Invalid backup file format');
+                        }
+
+                        localStorage.setItem('flow-state-storage', json);
+                        toast.success('Data restored successfully! Reloading...');
+
+                        setTimeout(() => {
+                          window.location.reload();
+                        }, 1500);
+                      } catch (error) {
+                        console.error('Import failed:', error);
+                        toast.error('Failed to restore data. Invalid file.');
+                      }
+                    };
+                    reader.readAsText(file);
+
+                    // Reset input
+                    e.target.value = '';
+                  }}
+                />
+                <Button variant="outline" className="w-full justify-start overflow-hidden pointer-events-none">
+                  <Upload className="mr-2 h-4 w-4 shrink-0" />
+                  <span className="truncate">Import Backup</span>
+                </Button>
+              </div>
+            </div>
+
+            <p className="text-muted-foreground text-xs pt-2">
+              Importing a backup will overwrite your current data. This action cannot be undone.
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <h3 className="text-muted-foreground text-sm font-medium">
+            Reset Options
+          </h3>
+          <div className="bg-card space-y-4 rounded-xl border p-4">
+            <div className="flex items-center gap-2 mb-2">
+              <RefreshCw className="text-warning h-4 w-4" />
+              <Label className="text-foreground">Session & Data Reset</Label>
+            </div>
+
+            <div className="grid grid-cols-2 gap-3">
+              <Button
+                variant="outline"
+                className="w-full justify-start overflow-hidden border-warning/50 hover:bg-warning/10"
+                onClick={() => {
+                  if (confirm('Are you sure you want to reset the sessions? This will take you back to session 1.')) {
+                    resetSessions();
+                    toast.success('Sessions reset successfully!');
+                  }
+                }}
+              >
+                <RefreshCw className="mr-2 h-4 w-4 shrink-0 text-warning" />
+                <span className="truncate">Reset Sessions</span>
+              </Button>
+
+              <Button
+                variant="outline"
+                className="w-full justify-start overflow-hidden border-destructive/50 hover:bg-destructive/10"
+                onClick={() => {
+                  if (confirm('WARNING: This will delete ALL your information (sessions, habits, settings). This action CANNOT be undone. Are you completely sure?')) {
+                    if (confirm('Final confirmation: Do you really want to delete EVERYTHING?')) {
+                      hardReset();
+                      toast.success('All data has been reset!');
+                    }
+                  }
+                }}
+              >
+                <Trash2 className="mr-2 h-4 w-4 shrink-0 text-destructive" />
+                <span className="truncate">Hard Reset</span>
               </Button>
             </div>
+
+            <p className="text-muted-foreground text-xs pt-2">
+              <strong>Reset Sessions:</strong> Resets the session counter to 1 without losing your historical data.<br />
+              <strong>Hard Reset:</strong> Permanently deletes ALL application data.
+            </p>
           </div>
-          
-          <p className="text-muted-foreground text-xs pt-2">
-            Importing a backup will overwrite your current data. This action cannot be undone.
-          </p>
         </div>
-      </div>
       </div>
 
       {/* Data Note */}

--- a/components/settings/updates-modal.tsx
+++ b/components/settings/updates-modal.tsx
@@ -12,11 +12,21 @@ import { Button } from '@/components/ui/button';
 import { Sparkles, CheckCircle2 } from 'lucide-react';
 
 // Update this array to add new updates - also la version (nota para mi, esto deberia reflejarse en el release de github y en el manifest.json)
-const APP_VERSION = 'v1.0.3';
+const APP_VERSION = 'v1.0.4';
 const UPDATES = [
-  {title: 'Separation tab on charts', 
-    description: 'Now you can see your focus activity separated of the habit tracker.',},
-  
+  {
+    title: 'Session Reset Options',
+    description: 'New reset buttons to restart your session counter or completely reset all app data. Reset Sessions brings you back to session 1, while Hard Reset clears everything.',
+  },
+  {
+    title: 'Category Lock During Sessions',
+    description: 'Categories are now locked when the timer is active, preventing accidental changes during your focus sessions.',
+  },
+  {
+    title: 'Separation tab on charts',
+    description: 'Now you can see your focus activity separated of the habit tracker.',
+  },
+
   {
     title: 'Session Categories',
     description: 'Label your focus sessions by category (Work, Study, Code, etc.) and track your time distribution with beautiful analytics and detailed statistics.',
@@ -67,9 +77,9 @@ export function UpdatesModal() {
             </div>
           ))}
         </div>
-        
+
         <div className="text-muted-foreground text-xs text-center border-t pt-4">
-           InTheZone {APP_VERSION}
+          InTheZone {APP_VERSION}
         </div>
       </DialogContent>
     </Dialog>

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -33,6 +33,8 @@ interface AppActions {
 
   updateSettings: (settings: Partial<PomodoroSettings>) => void;
   setSelectedCategory: (category: Category) => void;
+  resetSessions: () => void;
+  hardReset: () => void;
 
   // Habit Actions
   addHabit: (input: CreateHabitInput) => void;
@@ -118,13 +120,13 @@ export const useAppStore = create<AppState & AppActions>()(
           id: crypto.randomUUID(),
           startedAt: new Date(
             Date.now() -
-              (state.currentSessionType === 'focus'
-                ? state.settings.focusDuration
-                : state.currentSessionType === 'shortBreak'
-                  ? state.settings.shortBreakDuration
-                  : state.settings.longBreakDuration) *
-                60 *
-                1000
+            (state.currentSessionType === 'focus'
+              ? state.settings.focusDuration
+              : state.currentSessionType === 'shortBreak'
+                ? state.settings.shortBreakDuration
+                : state.settings.longBreakDuration) *
+            60 *
+            1000
           ).toISOString(),
           endedAt: now,
           duration:
@@ -178,7 +180,7 @@ export const useAppStore = create<AppState & AppActions>()(
           nextType =
             (state.completedSessions + 1) %
               state.settings.sessionsUntilLongBreak ===
-            0
+              0
               ? 'longBreak'
               : 'shortBreak';
         } else {
@@ -216,6 +218,30 @@ export const useAppStore = create<AppState & AppActions>()(
                 : settings.longBreakDuration;
           set({ timeRemaining: duration * 60 });
         }
+      },
+
+      resetSessions: () => {
+        const state = get();
+        set({
+          pomodoroState: 'idle',
+          timeRemaining: state.settings.focusDuration * 60,
+          currentSessionType: 'focus',
+          completedSessions: 0,
+        });
+      },
+
+      hardReset: () => {
+        set({
+          pomodoroState: 'idle',
+          timeRemaining: DEFAULT_SETTINGS.focusDuration * 60,
+          currentSessionType: 'focus',
+          completedSessions: 0,
+          sessions: [],
+          settings: DEFAULT_SETTINGS,
+          habits: [],
+          completions: [],
+          selectedCategory: 'work',
+        });
       },
 
       // Habit Actions
@@ -419,7 +445,7 @@ export const useAppStore = create<AppState & AppActions>()(
             sessionDates[0] === today
               ? new Date()
               : new Date(Date.now() - 86400000);
-          
+
           for (const dateStr of sessionDates) {
             const expectedDate = checkDate.toISOString().split('T')[0];
             if (dateStr === expectedDate) {


### PR DESCRIPTION
## ✨ Features

### Category Lock During Active Sessions (#9)
- Categories are now locked when the timer is running
- Prevents accidental changes during focus sessions
- Visual feedback with disabled state and reduced opacity

### Session Reset Options (#7)

**Reset Sessions Button (Main View)**
- Appears below "Session X of 4" when not on session 1
- Resets counter to session 1 while preserving history
- Quick access with simple confirmation

**Settings Reset Options**
- **Reset Sessions**: Resets session counter, keeps all data
- **Hard Reset**: Complete data wipe (double confirmation required)

## 🔧 Technical Changes
- Added [resetSessions()](cci:1://file:///c:/Users/juan_/Desktop/SimpleDevs/InTheZone/lib/store.ts:222:6-230:7) and [hardReset()](cci:1://file:///c:/Users/juan_/Desktop/SimpleDevs/InTheZone/lib/store.ts:232:6-244:7) to store
- Updated version to v1.0.4
- Modified: [liquid-timer.tsx](cci:7://file:///c:/Users/juan_/Desktop/SimpleDevs/InTheZone/components/pomodoro/liquid-timer.tsx:0:0-0:0), [settings-view.tsx](cci:7://file:///c:/Users/juan_/Desktop/SimpleDevs/InTheZone/components/settings/settings-view.tsx:0:0-0:0), [updates-modal.tsx](cci:7://file:///c:/Users/juan_/Desktop/SimpleDevs/InTheZone/components/settings/updates-modal.tsx:0:0-0:0), [store.ts](cci:7://file:///c:/Users/juan_/Desktop/SimpleDevs/InTheZone/lib/store.ts:0:0-0:0)

## 🔗 Closes
#9, #7